### PR TITLE
fix: button now have correct bounds for click and hover

### DIFF
--- a/sources/systems/click.cpp
+++ b/sources/systems/click.cpp
@@ -122,8 +122,13 @@ void Click::update(ecs::ComponentRegistry &componentRegistry,
     const auto worldTransform =
         detail::calculateWorldTransform(componentRegistry, identityIdentifier);
     const auto size = bound.getSize();
+
+    guillaume::components::Transform::Position trueCenter;
+    trueCenter[0] = worldTransform.position[0];
+    trueCenter[1] = worldTransform.position[1] - (size[1] * worldTransform.scale[1] / 2.0f);
+
     const bool isInside = isPointInsideEntityBounds(
-        worldMousePos, worldTransform.position, size, worldTransform.scale,
+        worldMousePos, trueCenter, size, worldTransform.scale,
         worldTransform.rotation);
 
     _evaluatedEntities.insert(identityIdentifier);

--- a/sources/systems/hover.cpp
+++ b/sources/systems/hover.cpp
@@ -57,7 +57,7 @@ static bool isPointInsideEntityBounds(
     const typename guillaume::components::Transform::Scale &entityScale,
     const typename guillaume::components::Transform::Rotation &entityRotation) {
     constexpr float degreeToRadian = 0.01745329251994329576923690768489f;
-    const float rotationRadians = -entityRotation[2] * degreeToRadian;
+    const float rotationRadians = entityRotation[2] * degreeToRadian;
     const float cosine = std::cos(rotationRadians);
     const float sine = std::sin(rotationRadians);
 
@@ -110,8 +110,13 @@ void Hover::update(ecs::ComponentRegistry &componentRegistry,
     const auto worldTransform =
         detail::calculateWorldTransform(componentRegistry, identityIdentifier);
     const auto size = bound.getSize();
+
+    guillaume::components::Transform::Position trueCenter;
+    trueCenter[0] = worldTransform.position[0];
+    trueCenter[1] = worldTransform.position[1] - (size[1] * worldTransform.scale[1] / 2.0f);
+
     const bool isInside = isPointInsideEntityBounds(
-        worldMousePos, worldTransform.position, size, worldTransform.scale,
+        worldMousePos, trueCenter, size, worldTransform.scale,
         worldTransform.rotation);
 
     if (isInside) {


### PR DESCRIPTION
**As shown in this proof video, the button's hitboxes are now correctly calculated and both click and hover works perfectly.**


https://github.com/user-attachments/assets/8c250c46-cfa5-451d-9b58-5d69d1464764

